### PR TITLE
Add npm script to compile basscss, run it postinstall

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,7 @@ or safe at all.
 - [ ] Better detection of PGP encrypted emails
 - [x] Text input for passphrase
 - [ ] Spec tests for all features
+
+## Commands
+
+- `npm run compile:basscss`: Compiles the `base.css` file in the `basscss` folder

--- a/package.json
+++ b/package.json
@@ -57,6 +57,10 @@
     "postcss-selector-prefix": "^2.0.0",
     "request": "^2.67.0"
   },
+  "scripts": {
+    "postinstall": "npm run compile:basscss",
+    "compile:basscss": "node basscss/compile.js"
+  },
   "license": "MIT",
   "windowTypes": {
     "default": true,


### PR DESCRIPTION
Added a new npm script (`npm run compile:basscss`) that compiles basscss. I then added that to the `postinstall` script, which means after a new developer runs `npm install` basscss will be compiled.

Otherwise they'll get a "Cannot find compiled.min.css" error when they first install cypher for development and will get confused (and probably won't contribute)
