### PR TITLE
Add empty username and passphrase check to keybase login form

### DIFF
--- a/lib/settings/preferences-component.es6
+++ b/lib/settings/preferences-component.es6
@@ -177,9 +177,15 @@ class PreferencesComponent extends React.Component {
   }
 
   loginToKeybase() {
+    let { username, passphrase } = this.state;
+    if (username === '' || passphrase === '') {
+      this.setState({
+        error: 'Please provide a username and passphrase!'
+      });
+      return;
+    }
     console.log('[PGP] Keybase Login');
 
-    let { username, passphrase } = this.state;
     //console.log('%s %s', username, passphrase);
 
     this.setState(Object.assign({}, this.defaultState, {


### PR DESCRIPTION
Render an error when either the username or the passphrase are empty, otherwise keybase will throw an error but the user won't see anything going wrong.
